### PR TITLE
AV-211558 Increase controller VM memory to prevent Terraform timeouts

### DIFF
--- a/examples/vmware/vmware_deploy_module_example/versions.tf
+++ b/examples/vmware/vmware_deploy_module_example/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    avi = {
+      source = "vmware/avi"
+    }
+  }
 }

--- a/examples/vmware/vmware_deploy_module_example/vmware_deploy.tf
+++ b/examples/vmware/vmware_deploy_module_example/vmware_deploy.tf
@@ -1,25 +1,24 @@
 provider "vsphere" {
-  user           = var.vsphere_user
-  password       = var.vsphere_password
-  vsphere_server = var.vsphere_server
+  user                 = var.vsphere_user
+  password             = var.vsphere_password
+  vsphere_server       = var.vsphere_server
   allow_unverified_ssl = true
-  version = "1.15.0"
 }
 
 module "vmware_deploy" {
   source = "../../../modules/services/vmware_deploy"
 
-  vm_datastore = var.vm_datastore
+  vm_datastore     = var.vm_datastore
   vm_resource_pool = var.vm_resource_pool
-  vm_datacenter = var.vm_datacenter
-  vm_network = var.vm_network
-  vm_template = var.vm_template
-  vm_name = var.vm_name
-  vm_folder = var.vm_folder
+  vm_datacenter    = var.vm_datacenter
+  vm_network       = var.vm_network
+  vm_template      = var.vm_template
+  vm_name          = var.vm_name
+  vm_folder        = var.vm_folder
 
   avi_new_password = var.avi_new_password
-  avi_password = var.avi_password
-  avi_username = var.avi_username
+  avi_password     = var.avi_password
+  avi_username     = var.avi_username
 }
 
 output "controller_1" {
@@ -35,6 +34,7 @@ output "controller_3" {
 }
 
 output "avi_cluster_output" {
-  value = module.vmware_deploy.avi_cluster_output
+  value     = module.vmware_deploy.avi_cluster_output
+  sensitive = true
 }
 

--- a/modules/services/vmware_deploy/main.tf
+++ b/modules/services/vmware_deploy/main.tf
@@ -29,14 +29,14 @@ data "vsphere_virtual_machine" "template" {
 }
 
 resource "vsphere_virtual_machine" "vm" {
-  name             = "${var.vm_name}-${count.index+1}"
+  name             = "${var.vm_name}-${count.index + 1}"
   resource_pool_id = data.vsphere_resource_pool.resource_pool.id
   datastore_id     = data.vsphere_datastore.datastore.id
-  count = 3
-  num_cpus = 8
-  memory = 24576
-  guest_id = data.vsphere_virtual_machine.template.guest_id
-  scsi_type = data.vsphere_virtual_machine.template.scsi_type
+  count            = 3
+  num_cpus         = 8
+  memory           = 32768
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
 
   folder = var.vm_folder
   network_interface {
@@ -45,9 +45,9 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    label = "disk1"
-    size = data.vsphere_virtual_machine.template.disks.0.size
-    unit_number = 0
+    label            = "disk1"
+    size             = data.vsphere_virtual_machine.template.disks.0.size
+    unit_number      = 0
     eagerly_scrub    = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
     thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
   }
@@ -58,10 +58,11 @@ resource "vsphere_virtual_machine" "vm" {
 }
 
 provider "avi" {
-  avi_username   = var.avi_username
-  avi_password   = var.avi_password
-  avi_controller = vsphere_virtual_machine.vm[0].default_ip_address
-  avi_tenant     = "admin"
+  avi_username    = var.avi_username
+  avi_password    = var.avi_password
+  avi_controller  = vsphere_virtual_machine.vm[0].default_ip_address
+  avi_tenant      = "admin"
+  avi_api_timeout = var.avi_api_timeout
 }
 
 resource "avi_useraccount" "avi_user" {

--- a/modules/services/vmware_deploy/variables.tf
+++ b/modules/services/vmware_deploy/variables.tf
@@ -48,3 +48,9 @@ variable "avi_new_password" {
   type = string
   default = ""
 }
+
+variable "avi_api_timeout" {
+  type    = number
+  default = 3000
+  description = "Timeout in seconds for waiting for Avi Controller API to be ready and for individual API requests"
+}


### PR DESCRIPTION
Issue: https://vmw-jira.broadcom.net/browse/AV-211558

### Summary
Terraform timeouts were caused by insufficient memory allocated to the controller VM. The module currently configures the controller with 24 GB RAM, which is not adequate for newer controller versions.

### Details

Reproduced the issue consistently with 24 GB RAM, where the controller failed to reach a ready state and Terraform timed out while waiting for the API.

Increasing the memory to 30–34 GB allowed the controller to boot successfully and Terraform to complete reliably.

Validated this behavior by reducing an existing controller from 32 GB to 24 GB (failed to come up even after several hours) and restoring it back to 32 GB, which resolved the issue.

### Fix

Updated the VMware module to increase the controller VM memory to prevent boot delays and Terraform execution timeouts.